### PR TITLE
Format cablegram in Chapter 8

### DIFF
--- a/src/epub/text/chapter-8.xhtml
+++ b/src/epub/text/chapter-8.xhtml
@@ -209,7 +209,7 @@
 				<p>“Go on,” he said curtly.</p>
 				<p>“Then Hiram Potts got mixed up in it; exactly how, we weren’t wise to. But it was enough to bring me over here. Two days ago I got this cable.” He produced a bundle of papers, and handed one to Drummond. “It’s in cipher, as you see; I’ve put the translation underneath.”</p>
 				<p>Hugh took the cablegram and glanced at it. It was short and to the point:</p>
-				<blockquote epub:type="z3998:letter">
+				<blockquote class="telegram" epub:type="z3998:letter">
 					<p>“Captain Hugh Drummond, of Half Moon Street, London, is your man.”</p>
 				</blockquote>
 				<p>He glanced up at the American, who drained his cocktail with the air of a man who is satisfied with life.</p>


### PR DESCRIPTION
The telegram styling was already present in the `local.css` file here, too.